### PR TITLE
Changed consensus consts for finality certainty

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -570,7 +570,7 @@ pub fn new_full_base(
 			force_authoring,
 			backoff_authoring_blocks,
 			babe_link,
-			block_proposal_slot_portion: SlotProportion::new(0.5),
+			block_proposal_slot_portion: SlotProportion::new(0.25) // changeed from 0.5, slower production rate,
 			max_block_proposal_slot_portion: None,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
@@ -681,8 +681,8 @@ pub fn new_full_base(
 
 	let grandpa_config = grandpa::Config {
 		// FIXME #1578 make this available through chainspec
-		gossip_duration: std::time::Duration::from_millis(333),
-		justification_period: 512,
+		gossip_duration: Duration::from_millis(1000), // Changed from 333
+    	justification_period: 256,
 		name: Some(name),
 		observer_enabled: false,
 		keystore,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -570,7 +570,7 @@ pub fn new_full_base(
 			force_authoring,
 			backoff_authoring_blocks,
 			babe_link,
-			block_proposal_slot_portion: SlotProportion::new(0.25) // changeed from 0.5, slower production rate,
+			block_proposal_slot_portion: SlotProportion::new(0.25), // changeed from 0.5, slower production rate,
 			max_block_proposal_slot_portion: None,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};

--- a/runtime/gpu/constants/src/lib.rs
+++ b/runtime/gpu/constants/src/lib.rs
@@ -42,9 +42,9 @@ pub mod currency {
 pub mod time {
 	use primitives::{BlockNumber, Moment};
 	use runtime_common::prod_or_fast;
-	pub const MILLISECS_PER_BLOCK: Moment = 6000;
+	pub const MILLISECS_PER_BLOCK: Moment = 12000;// Increase to 12 seconds;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(4 * HOURS, 1 * MINUTES); //shubhchange
+	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(2 * HOURS, 1 * MINUTES); //shubhchange
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/gpu/src/lib.rs
+++ b/runtime/gpu/src/lib.rs
@@ -553,8 +553,8 @@ impl OnUnbalanced<NegativeImbalance<Runtime>> for SudoAccount {
 }
 
 parameter_types! {
-	// Six sessions in an era (24 hours).
-	pub const SessionsPerEra: SessionIndex = prod_or_fast!(6, 1);//shubhchange
+	// Six sessions in an era (24 hours). Changed to 4
+	pub const SessionsPerEra: SessionIndex = prod_or_fast!(4, 1);//shubhchange
 
 	// 28 eras for unbonding (28 days).
 	pub const BondingDuration: sp_staking::EraIndex = 28;
@@ -747,6 +747,8 @@ impl pallet_grandpa::Config for Runtime {
 	type WeightInfo = ();
 	type MaxAuthorities = MaxAuthorities;
 	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
+
+	
 
 	type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
 


### PR DESCRIPTION
Modified consensus parameters to improve finalization rate and reduce gap between block production and finalization:
- Increased GRANDPA gossip duration (333ms → 1000ms) for better vote propagation
- Reduced justification period (512 → 256) for faster finality confirmation  
- Increased block time (6s → 12s) to allow more time for finalization
- Adjusted BABE probability (1/4 → 1/3) and reduced epoch duration for better block production pacing
- Optimized session length (6 → 4) for more frequent validator updates

These changes aim to prevent block production from overtaking finalization while maintaining network stability.